### PR TITLE
drop through2

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -37,9 +37,8 @@ import * as once from 'onetime';
 import * as os from 'os';
 const pumpify = require('pumpify');
 import * as resumableUpload from 'gcs-resumable-upload';
-import {Duplex, Writable, Readable} from 'stream';
+import {Duplex, Writable, Readable, PassThrough} from 'stream';
 import * as streamEvents from 'stream-events';
-import * as through from 'through2';
 import * as xdgBasedir from 'xdg-basedir';
 import * as querystring from 'querystring';
 import * as zlib from 'zlib';
@@ -264,6 +263,64 @@ class ResumableUploadError extends Error {
  */
 class SigningError extends Error {
   name = 'SigningError';
+}
+
+/**
+ * Basic Passthrough Stream that overrides destroy method for Node 8 to also
+ * emit 'close'.
+ *
+ * @private
+ */
+class ThroughStream extends PassThrough {
+  destroyed: boolean;
+  errorEmitted: boolean;
+  closeEmitted: boolean;
+  constructor() {
+    super();
+    this.destroyed = false;
+    this.errorEmitted = false;
+    this.closeEmitted = false;
+  }
+
+  destroy(err: Error) {
+    if (Number(process.versions.node.split('.')[0]) < 10) {
+      if (this.destroyed) {
+        if (err && !this.errorEmitted) {
+          this.errorEmitted = true;
+          process.nextTick(this.emitError, this, err);
+        }
+        return this;
+      }
+      this.destroyed = true;
+      if (err) {
+        if (!this.errorEmitted) {
+          this.errorEmitted = true;
+          process.nextTick(() => {
+            this.emitError(this, err);
+            this.emitClose(this);
+          });
+        } else {
+          process.nextTick(this.emitClose, this);
+        }
+      }
+      return this;
+    } else {
+      PassThrough.prototype.destroy.call(this, err);
+    }
+    return this;
+  }
+
+  emitError(self: ThroughStream, err: Error) {
+    self.emit('error', err);
+  }
+
+  emitClose(self: ThroughStream) {
+    if (!this.closeEmitted) {
+      this.closeEmitted = true;
+      self.emit('close');
+    }
+    return;
+  }
 }
 
 /**
@@ -1191,7 +1248,45 @@ class File extends ServiceObject<File> {
 
     // tslint:disable-next-line:no-any
     let validateStream: any; // Created later, if necessary.
-    const throughStream = streamEvents(through()) as Duplex;
+    const throughStream = streamEvents(new ThroughStream());
+
+    // if (Number(process.versions.node.split('.')[0]) < 10) {
+    //   let destroyed = false;
+    //   let errorEmitted = false;
+    //   let closeEmitted = false;
+    //   throughStream.destroy = function(err) {
+    //     if (destroyed) {
+    //       if (err && !errorEmitted) {
+    //         errorEmitted = true;
+    //         process.nextTick(emitError, this, err);
+    //       }
+    //       return this;
+    //     }
+    //     destroyed = true;
+    //     if (err) {
+    //       if (!errorEmitted) {
+    //         errorEmitted = true;
+    //         process.nextTick(() => {
+    //           emitError(this, err);
+    //           emitClose(this);
+    //         });
+    //       } else {
+    //         process.nextTick(emitClose, this);
+    //       }
+    //     }
+    //     return this;
+    //   };
+    //   function emitClose(self: PassThrough) {
+    //     if (!closeEmitted) {
+    //       closeEmitted = true;
+    //       self.emit('close');
+    //     }
+    //     return;
+    //   }
+    //   function emitError(self: PassThrough, err: Error) {
+    //     self.emit('error', err);
+    //   }
+    // }
 
     let crc32c = true;
     let md5 = false;
@@ -1716,10 +1811,24 @@ class File extends ServiceObject<File> {
     });
 
     const fileWriteStream = duplexify();
+    // const passThrough = new PassThrough();
+
+    // if (Number(process.versions.node.split('.')[0]) < 10) {
+    //   passThrough._destroy = function(err) {
+    //     if (err) {
+    //       process.nextTick(() => {
+    //         this.emit('error', err);
+    //         this.emit('close');
+    //       });
+    //     } else {
+    //       process.nextTick(() => this.emit('close'));
+    //     }
+    //   };
+    // }
 
     const stream = streamEvents(
       pumpify([
-        gzip ? zlib.createGzip() : through(),
+        gzip ? zlib.createGzip() : new ThroughStream(),
         validateStream,
         fileWriteStream,
       ])

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2033,6 +2033,23 @@ describe('storage', () => {
       });
     });
 
+    (Number(process.versions.node.split('.')[0]) < 10
+      ? describe
+      : describe.skip)('Node 10 and up', () => {
+      it('should support readable[Symbol.asyncIterator]()', async () => {
+        const fileContents = fs.readFileSync(FILES.big.path);
+
+        const [file] = await bucket.upload(FILES.big.path);
+        const stream = file.createReadStream();
+        const chunks: Buffer[] = [];
+        for await (const chunk of stream) {
+          chunks.push(chunk);
+        }
+        const remoteContents = Buffer.concat(chunks).toString();
+        assert.strictEqual(String(fileContents), String(remoteContents));
+      });
+    });
+
     it('should download a file to memory', done => {
       const fileContents = fs.readFileSync(FILES.big.path);
       bucket.upload(FILES.big.path, (err: Error | null, file?: File | null) => {

--- a/test/file.ts
+++ b/test/file.ts
@@ -1020,12 +1020,12 @@ describe('File', () => {
 
         it('should emit errors from the request stream', done => {
           const error = new Error('Error.');
-          const rawResponseStream = through();
+          const rawResponseStream = new stream.PassThrough();
           // tslint:disable-next-line:no-any
           (rawResponseStream as any).toJSON = () => {
             return {headers: {}};
           };
-          const requestStream = through();
+          const requestStream = new stream.PassThrough();
 
           handleRespOverride = (
             err: Error,
@@ -1057,12 +1057,12 @@ describe('File', () => {
 
         it('should not handle both error and end events', done => {
           const error = new Error('Error.');
-          const rawResponseStream = through();
+          const rawResponseStream = new stream.PassThrough();
           // tslint:disable-next-line:no-any
           (rawResponseStream as any).toJSON = () => {
             return {headers: {}};
           };
-          const requestStream = through();
+          const requestStream = new stream.PassThrough();
 
           handleRespOverride = (
             err: Error,


### PR DESCRIPTION
Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
Propose to use native Node core stream (PassThrough) instead of `through2`.
Node 8 readable.destroy() does not emit `close` event (unlike Node 10).
To mitigate that introduced `ThroughStream` that extends `PassThrough` stream and overrides `.destroy` method for Node <10 version (instead of manually overriding in two different places)